### PR TITLE
تعديلات ثانوية

### DIFF
--- a/source/Alif5.cpp
+++ b/source/Alif5.cpp
@@ -10,6 +10,7 @@
 #include<string>
 #include<vector>
 #include<map>
+#include<math.h>
 #include<algorithm> // لعمل تتالي على المصفوفات
 #include<fcntl.h> //لقبول ادخال الاحرف العربية من الكونسل
 #include<io.h> //لقبول ادخال الاحرف العربية من الكونسل

--- a/source/AlifRun.h
+++ b/source/AlifRun.h
@@ -80,5 +80,7 @@ void terminal_run() {
         Parser parser = Parser(&lexer.tokens_, fileName, input_);
         parser.parse_terminal();
 
+        std::wcin.ignore(); // لمنع ارسال قيمة فارغة في المتغير input_
+
     }
 }


### PR DESCRIPTION
تم إضافة مكتبة الرياضيات لكي تعمل دالة std::pow في جميع المترجمات

تم إضافة std::wcin.ignore()
لمنع ارسال قيمة فارغة في متغير الادخال

هذه التعديلات تم عملها بسبب ظهور بعض المشاكل في ترجمة الشفرة في مترجم منفصل بنسخة 8.5