### PR TITLE
إضافة ملف .editorconfig لحل القضية #166

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# يُساعد هذا الملف على توحيد إعدادات مطوري المشروع
+# حيث يفرض هذه الإعدادات لدى المحررات وبيئات التطوير المتكاملة
+# لمعرفة المزيد: https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+indent_size = 4
+
+# سيتم إضافتهم لاحقًا بعد مناقشتهم مع المطورين
+# end_of_line = lf
+# insert_final_newline = true
+# trim_trailing_whitespace = true


### PR DESCRIPTION
تم، بحمد الله، إضافة مِلَفّ ‎`.editorconfig` لحل القضية رقم #166.

## خصائص مِلَفّ تهيئة/إعداد المُحرر (ما سيفرضه المُحرر على المُطورين):
- ترميز (UTF-8)
- نوع الإزاحة (مفتاح الجدولة؛ Tab)
- حجم الإزاحة (4)

###  لم تُضَف بعد (تحت النقاش):
- نهاية الأسطر (LF، CR-LF)
    - بحسب ما [شاهدت](https://github.com/editorconfig/editorconfig/wiki/Projects-Using-EditorConfig)، فمعظم المشاريع تستخدم نهاية LF (الخاصة بنظام لينكس) بدلًا من CR-LF (الخاص بنظام ويندوز).
- إضافة سطر جديد في نهاية المِلَفّ
    - يُنصح بشدة تفعيل هذه الخاصية، لأسباب منها: التوافقية، وتسهيل قراءة المِلَفّ من المترجمات وغيرها.
- حذف المسافات الزائدة في نهايات الأسطر